### PR TITLE
Port mod to Minecraft 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-	id 'fabric-loom' version '0.7-SNAPSHOT'
+	id 'fabric-loom' version '1.14-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
+
+base {
+	archivesName = project.archives_base_name
+}
 
 repositories {
 	// Add repositories to retrieve artifacts from in here.
@@ -26,9 +26,6 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-	// You may need to force-disable transitiveness on them.
 }
 
 processResources {
@@ -40,19 +37,8 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// ensure that the encoding is set to UTF-8, no matter what the system default is
-	// this fixes some edge cases with special characters not displaying correctly
-	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
-
-	// The Minecraft launcher currently installs Java 8 for users, so your mod probably wants to target Java 8 too
-	// JDK 9 introduced a new way of specifying this that will make sure no newer classes or methods are used.
-	// We'll use that if it's available, but otherwise we'll use the older option.
-	def targetVersion = 8
-	if (JavaVersion.current().isJava9Compatible()) {
-		 it.options.release = targetVersion
-	}
+	it.options.release = 21
 }
 
 java {
@@ -60,11 +46,14 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.base.archivesName.get()}"}
 	}
 }
 
@@ -72,13 +61,7 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
+			from components.java
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.16.5
-	yarn_mappings=1.16.5+build.9
-	loader_version=0.11.3
+# check these on https://fabricmc.net/develop/
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.3
+loader_version=0.18.3
 
 # Mod Properties
-	mod_version = 1.0
-	maven_group = furnygo.paragraphs
-	archives_base_name = paragraphs
+mod_version=1.2.0
+maven_group=furnygo.paragraphs
+archives_base_name=paragraphs
 
 # Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api (or https://fabricmc.net/versions.html)
-	fabric_version=0.34.2+1.16
+fabric_version=0.140.2+1.21.11

--- a/src/main/java/furnygo/paragraphs/mixin/MixinStringHelper.java
+++ b/src/main/java/furnygo/paragraphs/mixin/MixinStringHelper.java
@@ -1,20 +1,20 @@
 package furnygo.paragraphs.mixin;
 
-import net.minecraft.SharedConstants;
+import net.minecraft.util.StringHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(SharedConstants.class)
-public class MixinSharedConstants {
+@Mixin(StringHelper.class)
+public class MixinStringHelper {
 
 	/**
 	 * @author Morgz
-	 * Makes you able to "chat" § etc. (normally "illegal" characters)
+	 * Makes you able to "chat" section sign and other normally "illegal" characters
 	 */
 	@Inject(method = "isValidChar", at = @At(value = "HEAD"), cancellable = true)
-	private static void isValidChar(CallbackInfoReturnable<Boolean> info) {
+	private static void isValidChar(int c, CallbackInfoReturnable<Boolean> info) {
 		info.setReturnValue(true);
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "${version}",
 
   "name": "Paragraphs",
-  "description": "Mod that allows you to write paragraphs",
+  "description": "Mod that allows you to write section signs and other special characters in chat",
   "authors": [
     "FurnyGo"
   ],
@@ -26,8 +26,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
-    "fabric": "*",
-    "minecraft": ">=1.16"
+    "fabricloader": ">=0.18.0",
+    "minecraft": "~1.21.11",
+    "java": ">=21"
   }
 }

--- a/src/main/resources/paragraphs.mixins.json
+++ b/src/main/resources/paragraphs.mixins.json
@@ -2,9 +2,9 @@
   "required": true,
   "minVersion": "0.8",
   "package": "furnygo.paragraphs.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "MixinSharedConstants"
+    "MixinStringHelper"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Update Fabric Loom from 0.7 to 1.14
- Update yarn mappings to 1.21.11+build.3
- Update Fabric API to 0.140.2+1.21.11
- Update Fabric Loader requirement to 0.18.0+
- Migrate from Java 8 to Java 21
- Fix mixin: move from SharedConstants.isValidChar to StringHelper.isValidChar (the method was relocated in newer Minecraft versions)
- Update method signature from isValidChar(char) to isValidChar(int)